### PR TITLE
Return component wrapped in a Fragment instead of a div

### DIFF
--- a/src/Laika.js
+++ b/src/Laika.js
@@ -32,9 +32,9 @@ export default class Laika extends Component {
     const Children = (this.state && this.state[feature]) ? onTrue : onFalse
 
     return (
-      <div>
+      <>
         { (!loading && fetched) && Children}
-      </div>
+      </>
     )
   }
 }


### PR DESCRIPTION
The current implementation returns the component passed to onTrue/onFalse wrapped in div. It would be better to have a Fragment instead. This will prevent styling issues and give us the option of returning "null" instead of an empty div when onFalse/onTrue is "null".