### PR TITLE
*hotifx - fix tsc to output commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laika-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React Laika client",
   "homepage": "https://github.com/MEDIGO",
   "keywords": [
@@ -53,7 +53,6 @@
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "html-webpack-plugin": "^5.3.2",
-    "lib": "link:./src",
     "local-cypress": "^1.2.2",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.4.1",

--- a/src/component.test.tsx
+++ b/src/component.test.tsx
@@ -1,9 +1,9 @@
 import { mount } from '@cypress/react'
-import { Laika } from 'lib/component'
-import { Config, LaikaContext } from 'lib/config'
-import { mockRequest } from 'lib/mock/mockRequest'
 import { cy, describe, it } from 'local-cypress'
 import React from 'react'
+import { Laika } from './component'
+import { Config, LaikaContext } from './config'
+import { mockRequest } from './mock/mockRequest'
 
 describe('component', () => {
   const uri = 'https://laika.example.com'

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -1,6 +1,6 @@
 import { bool, node, number, oneOfType, string } from 'prop-types'
 import React from 'react'
-import { useLaika } from 'lib/hook'
+import { useLaika } from './hook'
 
 export interface LaikaProps {
   feature: string

--- a/src/hook.test.tsx
+++ b/src/hook.test.tsx
@@ -1,9 +1,9 @@
 import { mount } from '@cypress/react'
-import { Config, LaikaContext } from 'lib/config'
-import { useLaika } from 'lib/hook'
-import { mockRequest } from 'lib/mock/mockRequest'
 import { cy, describe, it } from 'local-cypress'
 import React from 'react'
+import { Config, LaikaContext } from './config'
+import { useLaika } from './hook'
+import { mockRequest } from './mock/mockRequest'
 
 describe('useLaika', () => {
   const uri = 'https://laika.example.com'

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,6 +1,6 @@
-import { LaikaContext } from 'lib/config'
-import { DEFAULT_TIMEOUT, getFeatureStatus } from 'lib/utils'
 import { useContext, useEffect, useRef, useState } from 'react'
+import { LaikaContext } from './config'
+import { DEFAULT_TIMEOUT, getFeatureStatus } from './utils'
 
 export function useLaika(
   feature: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { getFeatureStatus } from 'lib/utils'
-export { useLaika } from 'lib/hook'
-export { Config, LaikaContext } from 'lib/config'
-export { Laika } from 'lib/component'
+export { getFeatureStatus } from './utils'
+export { useLaika } from './hook'
+export { Config, LaikaContext } from './config'
+export { Laika } from './component'

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { cy, describe, it } from 'local-cypress'
-import { mockRequest } from 'lib/mock/mockRequest'
-import { getFeatureStatus } from 'lib/utils'
+import { mockRequest } from './mock/mockRequest'
+import { getFeatureStatus } from './utils'
 
 describe('Utilities', () => {
   describe('getFeatureStatus', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     /* Basic Options */
     "incremental": true /* Enable incremental compilation */,
     "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
-    "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": [
       "es2017",
       "dom",
@@ -46,9 +46,6 @@
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "baseUrl": ".",
-    "paths": {
-      "lib/*": ["src/*"]
-    },
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -6238,7 +6238,6 @@ fsevents@~2.3.2:
     eslint-plugin-react: ^7.25.1
     eslint-plugin-react-hooks: ^4.2.0
     html-webpack-plugin: ^5.3.2
-    lib: "link:./src"
     local-cypress: ^1.2.2
     postinstall-postinstall: ^2.1.0
     prettier: ^2.4.1
@@ -6288,12 +6287,6 @@ fsevents@~2.3.2:
   checksum: 12c5021c859bd0f5248561bf139121f0358285ec545ebf48bb3d346820d5c61a4309535c7f387ed7d84361cf821e124ce346c6b7cef8ee09a67c1473b46d0fc4
   languageName: node
   linkType: hard
-
-"lib@link:./src::locator=laika-react%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "lib@link:./src::locator=laika-react%40workspace%3A."
-  languageName: node
-  linkType: soft
 
 "listr2@npm:^3.8.3":
   version: 3.12.2


### PR DESCRIPTION
Previous version created ESModules. They are nice and all, but unfortunately don't work from nodejs. Also we were using custom typescript paths before but they wouldn't be transpiled (and yarn didn't understand the yarn:link when resolving this package as a dependency), so this is to get rid of them as well.