### PR TITLE
*hotfix - fix registry server to use our package at npm instead of yarnpkg

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -18,3 +18,4 @@ jobs:
       - run: make publish
         env:
           YARN_NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+          YARN_NPM_REGISTRY_SERVER: https://registry.npmjs.org/


### PR DESCRIPTION
fix registry server to use our package at npm instead of yarnpkg