### PR TITLE
*hotfix - compile down to es2016 so it runs on older node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laika-react",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React Laika client",
   "homepage": "https://github.com/MEDIGO",
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     /* Basic Options */
     "incremental": true /* Enable incremental compilation */,
-    "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "target": "es2016" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": [
       "es2017",


### PR DESCRIPTION
It was complaining about the '??' operator when using with Jest.